### PR TITLE
fixed missing build dep gulp-connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "gulp": "^3.7.0",
     "gulp-concat": "^2.1.7",
+    "gulp-connect": "^2.2.0",
     "gulp-livereload": "^3.0.0",
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.1.0",


### PR DESCRIPTION
gulp-connect was missing from package.json - resulting outbuild from npm install then gulp build was: 
```console
gulp build
module.js:338
    throw err;
          ^
Error: Cannot find module 'gulp-connect'
```

This has now been corrected via npm install --save gulp-connect