### PR TITLE
Remove non-minified assets from bower main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,7 @@
   ],
   "description": "Ionic Material - Material Design for the Ionic Framework",
   "main": [
-    "./dist/ionic.material.css",
     "./dist/ionic.material.min.css",
-    "./dist/ionic.material.js",
     "./dist/ionic.material.min.js"
   ],
   "keywords": [


### PR DESCRIPTION
Only the minified assets is necessary as the bower main files.

This causes duplicate files to be included when using as part of a workflow (e.g gulp)