### PR TITLE
Include dist folder in paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Add `ionic.material.min.css` and `ionic.material.min.js` to your `index.html`
 
 ```html 
     <link href="lib/ionic/css/ionic.css" rel="stylesheet">
-    <link href="lib/ionic-material/ionic.material.min.css" rel="stylesheet">
+    <link href="lib/ionic-material/dist/ionic.material.min.css" rel="stylesheet">
     <link href="css/style.css" rel="stylesheet">
 
     <script src="lib/ionic/js/ionic.bundle.js"></script>
-    <script src="lib/ionic-material/ionic.material.min.js"></script>
+    <script src="lib/ionic-material/dist/ionic.material.min.js"></script>
 ```
 
 ### Step 4: Inject Ionic & Ionic Material into your Ionic App 


### PR DESCRIPTION
CSS and JavaScript files are clearly within a `dist` folder although it is not indicated in the setup guide.

![image](https://cloud.githubusercontent.com/assets/12778718/9152717/82e0e0e0-3e01-11e5-8c5c-d04fc984545e.png)
