### PR TITLE
fixed ion-md-input text overlap

### DIFF
--- a/demo/bower.json
+++ b/demo/bower.json
@@ -4,6 +4,6 @@
   "devDependencies": {
     "ionic": "driftyco/ionic-bower#1.0.0-rc.2",
     "ionic-material": "0.4.2",
-    "ion-md-input": "0.0.2"
+    "ion-md-input": "1.0.4"
   }
 }


### PR DESCRIPTION
The default login textholder has text overlapping problem. Update the ion-md-input version will fix this problem.