### PR TITLE
'Uncaught TypeError: Cannot read property 'className' of undefined'

### DIFF
--- a/src/js/lib/_motion.js
+++ b/src/js/lib/_motion.js
@@ -285,7 +285,12 @@ module.exports = function(angularApp) {
                     var delayValue = offset / speed / options.finishDelayThrottle;
                     var delay = parseFloat(delayValue).toFixed(2);
                 }
-                animateSlideInRightDom[0].className += ' done';
+
+                var animateSlide = animateSlideInRightDom[0];
+
+                if(animateSlide) {
+                    animateSlide.className += ' done';
+                }
 
             }, speed * options.finishSpeedPercent);
 


### PR DESCRIPTION
In _motion.js you reference to the first element in the array 'animateSlideInRightDom' without a check if there are any elements.

So I ran into the following error:
'Uncaught TypeError: Cannot read property 'className' of undefined'

Regards, patrick