### PR TITLE
Fix for 7 vulnerable dependency paths

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+version: v1.5.0
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - gulp > vinyl-fs > glob-stream > minimatch:
+        patched: '2016-06-27T09:10:54.876Z'
+    - gulp > vinyl-fs > glob-stream > glob > minimatch:
+        patched: '2016-06-27T09:10:54.876Z'

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "gulp-livereload": "^3.0.0",
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.1.0",
-    "gulp-uglify": "^0.2.1",
-    "lodash": "^3.9.1"
+    "gulp-uglify": "1.5.1",
+    "lodash": "^3.9.1",
+    "snyk": "1.16.0"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^1.1.0",
@@ -46,5 +47,10 @@
     "gulp-webpack": "^1.4.0",
     "node-libs-browser": "^0.5.0",
     "webpack": "^1.9.7"
-  }
+  },
+  "scripts": {
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }


### PR DESCRIPTION
###### 

Regular Expression Denial of Service
high severity

```
Vulnerable module: negotiator
Introduced through: gulp-connect@2.3.1
```

Detailed paths and remediation

```
Introduced through: ionic-material@sangramchavan/ionic-material#HEAD › gulp-connect@2.3.1 › connect@2.30.2 › serve-index@1.7.3 › accepts@1.2.13 › negotiator@0.5.3 Remediation: No direct dependency upgrade can address this issue. If possible, manually upgrade to connect@3.0.0. We'll notify you when an easier upgrade or a patch is available.
Introduced through: ionic-material@sangramchavan/ionic-material#HEAD › gulp-connect@2.3.1 › connect@2.30.2 › compression@1.5.2 › accepts@1.2.13 › negotiator@0.5.3 Remediation: No direct dependency upgrade can address this issue. If possible, manually upgrade to connect@3.0.0. We'll notify you when an easier upgrade or a patch is available.
```

Overview

negotiator is an HTTP content negotiator for Node.js. Versions prior to 0.6.1 are vulnerable to Regular expression Denial of Service (ReDoS) attack when parsing "Accept-Language" http header.

An attacker can provide a long value in the Accept-Language header, which nearly matches the pattern being matched. This will cause the regular expression matching to take a long time, all the while occupying the thread and preventing it from processing other requests. By repeatedly sending multiple such requests, the attacker can make the server unavailable (a Denial of Service attack).
###### 

Regular Expression Denial of Service
low severity

```
Vulnerable module: uglify-js
Introduced through: gulp-uglify@0.2.1
```

Detailed paths and remediation

```
Introduced through: ionic-material@sangramchavan/ionic-material#HEAD › gulp-uglify@0.2.1 › uglify-js@2.4.24 Remediation: Upgrade to gulp-uglify@1.5.1.
```

Overview

The parse() function in the uglify-js package prior to version 2.6.0 is vulnerable to regular expression denial of service (ReDoS) attacks when long inputs of certain patters are processed.
